### PR TITLE
Exclude eslint.config.js by default

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,8 @@
     "inlineSourceMap": true,
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true
-  }
+  },
+  "exclude": [
+    "${configDir}/eslint.config.js"
+  ]
 }


### PR DESCRIPTION
Having done a few modules, most only add an exclusion rule for `eslint.config.js`. By using the `${configDir}` template variable in the exculde rule, we can make it relative to the consuming TSConfig. Note however that if the downstream module adds its own set of excludes, this rule will be voided and they will need to include ESLint config once again.